### PR TITLE
카테고리 변경 시 스크롤 위치가 엇나가지 않도록 컨테이너 추가

### DIFF
--- a/src/components/contents/index.jsx
+++ b/src/components/contents/index.jsx
@@ -1,5 +1,6 @@
 import React, { useMemo } from 'react'
 
+import { ThumbnailContainer } from '../thumbnail-container'
 import { ThumbnailItem } from '../thumbnail-item'
 import { CATEGORY_TYPE } from '../../constants'
 
@@ -14,7 +15,11 @@ export const Contents = ({ posts, countOfInitialPost, count, category }) => {
       .slice(0, count * countOfInitialPost)
   )
 
-  return refinedPosts.map(({ node }, index) => (
-    <ThumbnailItem node={node} key={`item_${index}`} />
-  ))
+  return (
+    <ThumbnailContainer>
+      {refinedPosts.map(({ node }, index) => (
+        <ThumbnailItem node={node} key={`item_${index}`} />
+      ))}
+    </ThumbnailContainer>
+  )
 }

--- a/src/components/thumbnail-container/index.jsx
+++ b/src/components/thumbnail-container/index.jsx
@@ -1,0 +1,7 @@
+import React from 'react'
+
+import './index.scss'
+
+export const ThumbnailContainer = React.memo(({ children }) => (
+  <div className="thumbnail-container">{children}</div>
+))

--- a/src/components/thumbnail-container/index.scss
+++ b/src/components/thumbnail-container/index.scss
@@ -1,0 +1,3 @@
+.thumbnail-container {
+  min-height: calc(100vh - 3.5rem);
+}

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -16,7 +16,7 @@ import * as Dom from '../utils/dom'
 
 import { HOME_TITLE, CATEGORY_TYPE } from '../constants'
 
-const DEST_POS = 360
+const DEST_POS = 316
 const BASE_LINE = 80
 
 function getDistance(currentPos) {


### PR DESCRIPTION
@JaeYeopHan jbee.io 블로그 잘 보고 있습니다.

글이 많은 카테고리 사이를 움직일 때는 문제 없다가 글이 몇개 없는 etc 카테고리를 탐색할 때 스크롤 포지션이 초기화 되는게 다소 불편해서 코드를 추가해봤습니다. 

- 디스플레이 높이를 최소 크기로 가지는 컨테이너 추가
- 카테고리 변경 시 스크롤 이동 위치 조정