### PR TITLE
remove thumbnail code

### DIFF
--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -28,18 +28,11 @@ export default ({ data, pageContext, location }) => {
   const metaData = data.site.siteMetadata
   const { title, comment, siteUrl, author, sponsor } = metaData
   const { disqusShortName, utterances } = comment
-  const { title: postTitle, date, thumbnail } = post.frontmatter
-  const thumbnailSrc = thumbnail
-    ? `${siteUrl}${thumbnail.childImageSharp.fixed.src}`
-    : undefined
+  const { title: postTitle, date } = post.frontmatter
 
   return (
     <Layout location={location} title={title}>
-      <Head
-        title={postTitle}
-        description={post.excerpt}
-        thumbnail={thumbnailSrc}
-      />
+      <Head title={postTitle} description={post.excerpt} />
       <PostTitle title={postTitle} />
       <PostDate date={date} />
       <PostContainer html={post.html} />
@@ -86,13 +79,6 @@ export const pageQuery = graphql`
       frontmatter {
         title
         date(formatString: "MMMM DD, YYYY")
-        thumbnail {
-          childImageSharp {
-            fixed(width: 800) {
-              src
-            }
-          }
-        }
       }
     }
   }


### PR DESCRIPTION
현재 gatsby-start-bee 를 다운받아서 content - blog 안에 있는 샘플 포스트를 모두 삭제하면 에러가 발생합니다. ( #151 ) 없는 thumbnail을 찾기 때문인데  이를 찾아 내려주는 Header의 index.js에 propTypes안에도 thumbnail은 정의되어 있지 않고, 관련해 따로 사용하는 부분도 없는 것 같아 thumbnail 관련 코드를 삭제하고 PR 올려봅니다. 