### PR TITLE
fix: add type inference of thumbnail query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -68,3 +68,28 @@ exports.onCreateNode = ({ node, actions, getNode }) => {
     })
   }
 }
+
+exports.createSchemaCustomization = ({ actions }) => {
+  const { createTypes } = actions
+  const typeDefs = `
+    type MarkdownRemark implements Node {
+      frontmatter: Frontmatter
+    }
+    type Frontmatter {
+      thumbnail: Thumbnail
+    }
+
+    type Thumbnail {
+      childImageSharp: ChildImageSharp
+    }
+
+    type ChildImageSharp {
+      fixed(width: Int): Fixed
+    }
+
+    type Fixed {
+      src: String
+    }
+  `
+  createTypes(typeDefs)
+}

--- a/src/templates/blog-post.js
+++ b/src/templates/blog-post.js
@@ -29,9 +29,12 @@ export default ({ data, pageContext, location }) => {
   const { title, comment, siteUrl, author, sponsor } = metaData
   const { disqusShortName, utterances } = comment
   const { title: postTitle, date, thumbnail } = post.frontmatter
-  const thumbnailSrc = (thumbnail != null && thumbnail.childImageSharp != null && thumbnail.childImageSharp.fixed != null)
-    ? `${siteUrl}${thumbnail.childImageSharp.fixed.src}`
-    : undefined
+  const thumbnailSrc =
+    thumbnail != null &&
+    thumbnail.childImageSharp != null &&
+    thumbnail.childImageSharp.fixed != null
+      ? `${siteUrl}${thumbnail.childImageSharp.fixed.src}`
+      : undefined
 
   return (
     <Layout location={location} title={title}>


### PR DESCRIPTION
#151 에서 제가 버그를 발견했고 #155 에서 썸네일 관련 코드를 제거함으로써 문제를 해결했지만 og image 컨트롤 때문에 제거하지 못한다고 하셨습니다. 그리고 #156 에서 해결하시는듯 보였으나 여전히 문제가 해결되지 않았습니다. 요약하자면 문제는 다음과 같습니다.

- `blog-post.js` 에서 `thumbnail` 쪽 쿼리의 타입추론이 동작하지 않습니다.
- 이는 특정 조건을 만족해야 하는데, 블로그 포스트 마크다운 문서들 중 어떤 문서도 `thumbnail` 필드를 frontmatter에 가지고 있지 않아야 합니다.
- 이를 해결하기 위해 에러메시지는 `thumbnail` 필드를 가지고 있는 더미문서를 만들거나, 타입추론을 하도록 제시를 하는데 타입추론을 권장합니다.

따라서, [Gatsby 문서의 schema customization](https://www.gatsbyjs.org/docs/schema-customization) 문서를 읽고 `thumbnail` 을 가져오는 쿼리에 대한 타입추론을 추가하였습니다.