### PR TITLE
add use case && fix dark/light mode persistency

### DIFF
--- a/README.md
+++ b/README.md
@@ -63,6 +63,7 @@ In this template...
       <li>Garima's Tech Blog: https://garimasingh.netlify.app/ </li>
       <li>DevRappers.dev: https://devrappers.dev/</li>
       <li>Let's doodle: https://duduling-blog.netlify.app/</li>
+      <li>noopy.dev: https://noopy.dev/</li>
     </ul>
   </p>
 </details>

--- a/src/components/theme-switch/index.jsx
+++ b/src/components/theme-switch/index.jsx
@@ -2,6 +2,7 @@ import React, { useState, useEffect } from 'react'
 import Switch from 'react-switch'
 
 import * as Dom from '../../utils/dom'
+import * as Storage from '../../utils/storage'
 import { THEME } from '../../constants'
 
 import './index.scss'
@@ -56,12 +57,13 @@ export const ThemeSwitch = () => {
   const handleChange = checked => {
     const theme = getTheme(checked)
 
+    Storage.setTheme(checked)
     setChecked(checked)
     toggleTheme(theme)
   }
 
   useEffect(() => {
-    const checked = Dom.hasClassOfBody(THEME.DARK)
+    const checked = Storage.getTheme(Dom.hasClassOfBody(THEME.DARK))
 
     handleChange(checked)
   }, [])

--- a/src/utils/storage/index.js
+++ b/src/utils/storage/index.js
@@ -27,3 +27,11 @@ export function getData() {
 export function setData(val) {
   return setValueToLocalStorage(LOCAL_STORAGE_KEY, val)
 }
+
+export function getTheme(defaultValue) {
+  return getValueFromLocalStorage(`${LOCAL_STORAGE_KEY}/theme`) || defaultValue
+}
+
+export function setTheme(val) {
+  return setValueToLocalStorage(`${LOCAL_STORAGE_KEY}/theme`, val)
+}


### PR DESCRIPTION
Thanks for the blog template!
* add use case for README.md with noopy.dev blog site
* I fixed the issue #42 and #46. Now blog saves dark/light mode on Storage, fetches its dark/light theme when the page is refreshed.