### PR TITLE
fix: Enable Google Analytics for Germany && move GA script under <head> tag

### DIFF
--- a/gatsby-config.js
+++ b/gatsby-config.js
@@ -71,6 +71,8 @@ module.exports = {
       resolve: `gatsby-plugin-google-analytics`,
       options: {
         trackingId: metaConfig.ga,
+        head: true,
+        anonymize: true,
       },
     },
     {


### PR DESCRIPTION
Improved PR #177 
* Enable Google Analytics for countries like Germany. [Some countries (such as Germany) require you to use the _anonymizeIP function for Google Analytics. Otherwise you are not allowed to use it.](https://www.gatsbyjs.com/plugins/gatsby-plugin-google-analytics/#anonymize)
* move GA script under html <head> tag, instead of <body> tag.

