### PR TITLE
feat: github-icon in Top component add a link target attribute

### DIFF
--- a/src/components/social-share/github-icon/index.jsx
+++ b/src/components/social-share/github-icon/index.jsx
@@ -8,6 +8,7 @@ export const GitHubIcon = () => {
       href="https://github.com/JaeYeopHan/felog"
       className="github"
       aria-label="GitHub"
+      target="_blank"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"

--- a/src/components/social-share/github-icon/index.jsx
+++ b/src/components/social-share/github-icon/index.jsx
@@ -9,6 +9,7 @@ export const GitHubIcon = () => {
       className="github"
       aria-label="GitHub"
       target="_blank"
+      rel="noopener noreferrer"
     >
       <svg
         xmlns="http://www.w3.org/2000/svg"


### PR DESCRIPTION
- Top 영역의 Github 아이콘 링크에 target attribute 추가

오른쪽 상단의 github 연결 링크가 새창으로 열리게 추가 해봤습니다.
혹시 다른 의견 있으시면 부탁드리겠습니다.

p.s 글쓰기에 집중할 수 있는 template 정말 감사합니다 🙏