### PR TITLE
fix: Update social medium account link

### DIFF
--- a/src/components/bio/index.jsx
+++ b/src/components/bio/index.jsx
@@ -33,7 +33,7 @@ export const Bio = () => (
                     <a href={`https://github.com/${social.github}`}>GitHub</a>
                   )}
                   {social.medium && (
-                    <a href={`https://medium.com/${social.medium}`}>Medium</a>
+                    <a href={`https://${social.medium}.medium.com`}>Medium</a>
                   )}
                   {social.twitter && (
                     <a href={`https://twitter.com/${social.twitter}`}>


### PR DESCRIPTION
🐛  fix: Update social medium account link

medium account 등록 시 링크주소가 동작하지않아 현재 medium 홈링크 확인이후 변경했습니다