### PR TITLE
fix: issue#227 google analytics plugin related

### DIFF
--- a/gatsby-meta-config.js
+++ b/gatsby-meta-config.js
@@ -26,5 +26,5 @@ module.exports = {
   share: {
     facebookAppId: '', // Add facebookAppId for using facebook share feature v3.2
   },
-  ga: '', // Add your google analytics tranking ID
+  ga: '0', // Add your google analytics tranking ID
 }


### PR DESCRIPTION
There was an issue like below
https://github.com/JaeYeopHan/gatsby-starter-bee/issues/227
This was the problem of the empty value with the gatsby google analytics plugin
I could solve this problem by inserting my google analytics tracking id but I think many users might not need the google analytic feature.
So I thought we need to make it work instantly even if they don't have their analytics key.
By inserting simple '0' to the empty value I could solve this problem.

Thanks.

npt start를 하는 도중 아래와 같은 오류가 발생하였습니다.
https://github.com/JaeYeopHan/gatsby-starter-bee/issues/227
구글 애널리틱스에서 id가 없으면 곧 바로 버그 flag가 나와 작동이 중지하여 해당 오류를 회피하고자 0을 임시로 넣으니 에러 없이 빌드에 성공하였습니다.
![image](https://user-images.githubusercontent.com/25575989/106708511-58dbd080-6636-11eb-8df3-e4dfd8ea9711.png)


README에 해당하는 google analytics Tracking ID를 넣어야 한다는 문구를 추가하는 것이 더 나을지 고민하다가 해당 기능을 사용하지 않는 사용자도 고려하여 해당 에러 플래그를 회피하는 쪽으로 해결하였습니다.

감사합니다.