### PR TITLE
fix: make useIntersectionObserver.js reuseable

### DIFF
--- a/src/utils/visible.js
+++ b/src/utils/visible.js
@@ -36,7 +36,8 @@ export function init() {
 }
 
 export function destroy() {
-  return disconnect().then(() => (observer = null))
+  disconnect()
+  observer = null
 }
 
 export function refreshObserver() {


### PR DESCRIPTION
안녕하세요 jBee님 블로그 템플릿 너무 잘 쓰고 있습니다.

다른게 아니라 제가 커스터 마이징 중에 `thumbnail-container` - `thumbnail-item` 컴포넌트들 즉, 포스트 리스트에 대한 부분을 다른 페이지에서 재사용 해야될 필요가 생겼습니다. 

tag, 검색 결과 페이지를 새로 만들어서 여기서 다시 jBee님이 만들어두신 `thumbnail-container` - `thumbnail-item` 을 재사용한다고 생각하시면 편하실 것 같습니다. 그리고 그에따라 `thumbnail-item`에 종속된 Hook인 `useIntersectionObserver.js`을 사용하게 되었는데요,

여기서 메인페이지(index.js)에서 다른 `useIntersectionObserver` Hook을 사용하는 페이지로 넘어가게 될 경우에 
![image](https://user-images.githubusercontent.com/46669283/107705214-be4c5300-6d01-11eb-9195-1f26df239110.png)
다음과 같은 애러가 발생하였습니다.

확인해보니
 `useIntersectionObserver`의 첫번째 useEffect의 언마운트(return하는 함수)에서 호출되는 `IOManager.destroy()` 의 `observe.disconnect()` 비동기 작업 완료 후 `observe = null` 하는 부분에서 문제가 발생하게 되었습니다.

좀 더 상세히 말하자면 `useIntersectionObserver` Hook을 사용하는 다른 페이지로 바로 넘어가게 될 경우, init이 호출되어 새로운 
IntersectionObserver를 만드는데요, 이 새롭게 만들어진 observer에 이전 메인페이지 언마운트 작업으로 이루어지는 `observe.disconnect()` 비동기 작업 이후에 `observe = null`이 수행되어서 새로운 페이지상의 `observe`가 `null`이 되어버리는 현상이었습니다.

메인페이지(새 observer 생성) -> 다른 페이지 이동 - 메인페이지 언마운트로 observe.disconnect 비동기 작업 시작 -> 다른페이지 새 observer 생성 -> 메인페이지 언마운트의 observe.disconnect 비동기 작업 완료후 observe = null -> 다른페이지상에서 observe가 null이 되어버림.

입니다.

해결은 소스코드처럼
굳이 `observe.disconnect` 비동기 작업이 완료될 때까지 기다린 후에 observe = null을 수행할 연관성과 필요는 없다고 생각해서 disconnect작업 따로, `observe = null`을 따로 분리하였습니다.

그 뒤 refreshObserver에는 비동기로 받아 작업해야되므로 놔두었구요 visible.js의 destroy function만 건들였습니다.

jBee님도 `useIntersectionObserver` Hook을 사용하는 새로운 페이지를 만들면 동일 현상을 쉽게 확인 하실 수 있으리라 생각합니다.

이후 커스터마이징이 완성도 있게 끝나면 usecase로도 한번 올려보겠습니다.
그럼 이만 줄이겠습니다. 감사합니다.
