### PR TITLE
Refactor 'creating page' query

### DIFF
--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -24,6 +24,22 @@ exports.createPages = ({ graphql, actions }) => {
                 category
               }
             }
+            previous {
+              fields {
+                slug
+              }
+              frontmatter {
+                title
+              }
+            }
+            next {
+              fields {
+                slug
+              }
+              frontmatter {
+                title
+              }
+            }
           }
         }
       }
@@ -35,17 +51,14 @@ exports.createPages = ({ graphql, actions }) => {
 
     // Create blog posts pages.
     const posts = result.data.allMarkdownRemark.edges;
-    posts.forEach((post, index) => {
-      const previous = index === posts.length - 1 ? null : posts[index + 1].node
-      const next = index === 0 ? null : posts[index - 1].node
-
+    posts.forEach((post) => {
       createPage({
         path: post.node.fields.slug,
         component: blogPostTemplate,
         context: {
           slug: post.node.fields.slug,
-          previous,
-          next,
+          previous: post.next,
+          next: post.previous,
         },
       })
     })

--- a/gatsby-node.js
+++ b/gatsby-node.js
@@ -10,6 +10,7 @@ exports.createPages = ({ graphql, actions }) => {
     `
       {
         allMarkdownRemark(
+          filter: { frontmatter: { category: { ne: null }, draft: { eq: false } } }
           sort: { fields: [frontmatter___date], order: DESC }
           limit: 1000
         ) {
@@ -21,7 +22,6 @@ exports.createPages = ({ graphql, actions }) => {
               frontmatter {
                 title
                 category
-                draft
               }
             }
           }
@@ -34,10 +34,7 @@ exports.createPages = ({ graphql, actions }) => {
     }
 
     // Create blog posts pages.
-    const posts = result.data.allMarkdownRemark.edges.filter(
-      ({ node }) => !node.frontmatter.draft && !!node.frontmatter.category
-    )
-
+    const posts = result.data.allMarkdownRemark.edges;
     posts.forEach((post, index) => {
       const previous = index === posts.length - 1 ? null : posts[index + 1].node
       const next = index === 0 ? null : posts[index - 1].node


### PR DESCRIPTION
빌드 단계에서 포스팅 페이지 생성시 js 코드로 필터링하던 부분을
`pages/index.js`에서 사용되는 query와 동일한 query로 변경하고
이전, 다음글 로직도 query로 변경했습니다.

기능상 달라지는 것도, 빌드 속도가 의미있는만큼 달라지는 것도 아니지만
불필요한 filter를 없애고,
previous, next에 대해서 필요한 값만 사용될 수 있도록 했습니다.