### PR TITLE
:gift: feat: Enhance the scroll feature in useCategory hook

### DIFF
--- a/src/components/bio/index.jsx
+++ b/src/components/bio/index.jsx
@@ -1,17 +1,17 @@
-import React from 'react'
+import React, { forwardRef } from 'react'
 import { StaticQuery, graphql, Link } from 'gatsby'
 import Image from 'gatsby-image'
 
 import './index.scss'
 
-export const Bio = () => (
-  <StaticQuery
+export const Bio = forwardRef((props, ref) => {
+  return <StaticQuery
     query={bioQuery}
     render={data => {
       const { author, social, introduction } = data.site.siteMetadata
 
       return (
-        <div className="bio">
+        <div ref={ref} className="bio">
           <div className="author">
             <div className="author-description">
               <Image
@@ -63,7 +63,7 @@ export const Bio = () => (
       )
     }}
   />
-)
+})
 
 const bioQuery = graphql`
   query BioQuery {

--- a/src/hooks/useCategory.js
+++ b/src/hooks/useCategory.js
@@ -3,10 +3,11 @@ import qs from 'query-string'
 import { CATEGORY_TYPE } from '../constants'
 import * as ScrollManager from '../utils/scroll'
 
-const DEST_POS = 316
+let DEST_POS
 
-export function useCategory() {
+export function useCategory(DEST) {
   const [category, setCategory] = useState(CATEGORY_TYPE.ALL)
+  DEST_POS = DEST
   const adjustScroll = () => {
     if (window.scrollY > DEST_POS) {
       ScrollManager.go(DEST_POS)

--- a/src/pages/index.js
+++ b/src/pages/index.js
@@ -1,6 +1,6 @@
 import { graphql } from 'gatsby'
 import _ from 'lodash'
-import React, { useMemo } from 'react'
+import React, { useMemo, useRef, useEffect, useState } from 'react'
 import { Bio } from '../components/bio'
 import { Category } from '../components/category'
 import { Contents } from '../components/contents'
@@ -28,8 +28,14 @@ export default ({ data, location }) => {
     () => _.uniq(posts.map(({ node }) => node.frontmatter.category)),
     []
   )
+  const bioRef = useRef(null)
+  const [DEST, setDEST] = useState(316)
   const [count, countRef, increaseCount] = useRenderedCount()
-  const [category, selectCategory] = useCategory()
+  const [category, selectCategory] = useCategory(DEST)
+
+  useEffect( tabRef => {
+    setDEST(!bioRef.current ? 316 : bioRef.current.getBoundingClientRect().bottom + window.pageYOffset + 24 )
+  }, [bioRef.current])
 
   useIntersectionObserver()
   useScrollEvent(() => {
@@ -47,7 +53,7 @@ export default ({ data, location }) => {
   return (
     <Layout location={location} title={siteMetadata.title}>
       <Head title={HOME_TITLE} keywords={siteMetadata.keywords} />
-      <Bio />
+      <Bio ref={bioRef} />
       <Category
         categories={categories}
         category={category}


### PR DESCRIPTION
Modify the hooks that scroll to tag-container for respond any width
Change DEST_POS to the state value that based on bio.div using forwardRef

카테고리를 클릭했을때 최상단으로 스크롤하는 훅이 있습니다.
이때 기존에는 DEST_POS가 316이라는 고정 수치를 이용합니다.
브라우저의 너비에 따라 bio의 높이가 달라져 상단에 여백이 발생했습니다.
이를 해결하고자 bio 컴포넌트에 forwardRef를 적용하여 bio.div의 bottom 절대좌표를 기준으로 목표 지점을 수정하였습니다.